### PR TITLE
Optimize hyperdrive load

### DIFF
--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -27,6 +27,7 @@ module.exports = function (url, opts) {
   var swarm = hyperswarm(opts.swarmOpts || DEFAULT_SWARM_OPTS)
   drive.once('ready', function () {
     swarm.join(drive.discoveryKey)
+    if (!isOpen) open()
   })
   swarm.on('connection', function (socket, info) {
     var peer = info.peer
@@ -40,7 +41,6 @@ module.exports = function (url, opts) {
     socket.on('error', function (err) {
       console.log('hyperdrive: stream ERROR for peer', peer.host, err.message)
     })
-    if (!isOpen) open()
   })
 
   return {

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -31,7 +31,7 @@ module.exports = function (url, opts) {
   })
   swarm.on('connection', function (socket, info) {
     var peer = info.peer
-    console.log('replicate starting with peer', peer.host)
+    if (debug) console.log('replicate starting with peer', peer.host)
     pump(socket, drive.replicate(info.client), socket, function (err) {
       if (err) console.log('hyperdrive: pump ERROR', err.message)
     })


### PR DESCRIPTION
This reduces the amount of queued operations substantially. Once the drive is ready, we can start reading data from it, instead of waiting for the first connection in the swarm.