### PR TITLE
Add index.html file for local development

### DIFF
--- a/index-dev.html
+++ b/index-dev.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <title>peermaps (dev)</title>
+    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "scripts": {
-    "start": "npm run prepare && npm run web",
+    "start": "npm run prepare && cp index-dev.html public/index.html && npm run web",
     "build": "npm run prepare && npm run browserify",
     "prepare": "npm run prepare:config && npm run prepare:public && npm run prepare:style && npm run prepare:wasm",
     "prepare:config": "cp -n config.default.json config.json",


### PR DESCRIPTION
Developing for a mobile browser looks different from a deployed version. This
change makes sure that the index.html file used during development behaves in
the same way as indexhtmlify does.

Before:

![Screenshot from 2022-03-17 10-16-30](https://user-images.githubusercontent.com/308049/158778996-5f05046a-27de-45bf-9538-3b7e3eebbc1b.png)

After:

![Screenshot from 2022-03-17 10-20-16](https://user-images.githubusercontent.com/308049/158779044-c8770c9e-c303-4a28-87bf-0960d2d4c00c.png)
