### PR TITLE
Tweak settings for mobile (fixing issues in portrait orientation)

### DIFF
--- a/app.js
+++ b/app.js
@@ -198,6 +198,12 @@ app.route('*', function (state, emit) {
         font-family: monospace;
         color: white;
       }
+      svg {
+        fill: grey;
+      }
+      svg:hover {
+        fill: white;
+      }
       .ui-overlay {
         z-index: 2000;
       }

--- a/components/settings/index.js
+++ b/components/settings/index.js
@@ -27,6 +27,7 @@ function Settings (opts) {
       right: 0px;
       background: rgba(0, 0, 0, 0.7);
       height: 100%;
+      max-width: 100%;
     }
   `
   self.tabContainerStyle = css`

--- a/components/settings/index.js
+++ b/components/settings/index.js
@@ -67,18 +67,20 @@ function Settings (opts) {
       left: 0px;
       right: 0px;
       display: flex;
-      justify-content: end;
+      justify-content: space-between;
       align-items: center;
       border-top: 1px solid #999;
       padding-right: 10px;
+      display: flex;
     }
   `
   self.buttonStyle = css`
     :host {
       background: black;
-      width: 50px;
       text-align: center;
-      margin-left: 10px;
+      min-width: 20px;
+      width: 50px;
+      margin-left: 5px;
       margin-top: 0px;
       margin-bottom: 0px;
       padding: 5px;
@@ -320,9 +322,12 @@ Settings.prototype.renderButtons = function (emit) {
   }
 
   return html`<div class=${this.buttonContainerStyle}>
-    <div class=${this.buttonStyle} onclick=${() => emit('settings:reset')}>reset</div>
-    <div class=${this.buttonStyle} style=${cstyle(self.canReload)} onclick=${() => onReload()}>reload</div>
-    <div class=${this.buttonStyle} style=${cstyle(self.dirty)} onclick=${() => onApply()}>apply</div>
+    <a title='hide'><div class=${this.buttonStyle} style='max-width: 20px;' onclick=${() => emit('settings:toggle')}>${'>'}</div></a>
+    <div style='display: flex;'>
+      <div class=${this.buttonStyle} onclick=${() => emit('settings:reset')}>reset</div>
+      <div class=${this.buttonStyle} style=${cstyle(self.canReload)} onclick=${() => onReload()}>reload</div>
+      <div class=${this.buttonStyle} style=${cstyle(self.dirty)} onclick=${() => onApply()}>apply</div>
+    </div>
   </div>`
 }
 

--- a/components/settings/storage.js
+++ b/components/settings/storage.js
@@ -62,7 +62,6 @@ function StorageTab (config) {
       var content = data.storages.map(function (item, index) {
         var zoom = item.zoom
         return html`<div class=${storageStyle}>
-          <div style='position: absolute; right: 10px; cursor: pointer; padding-left: 4px; padding-right: 4px; border: 1px solid #999' onclick=${() => emit('settings:storage:delete', index)}>X</div>
           <label for='url'>data url</label>
           <input type='url' name='url' value=${item.url || ''} placeholder='https://example.com' required style='margin-top: 10px; margin-bottom: 10px; width: 100%;' onchange=${(e) => emit('settings:storage:url:update', index, e.target.value)}>
           <label for='minzoom'>min zoom level (${zoom[0]})</label>
@@ -72,7 +71,8 @@ function StorageTab (config) {
           <label for='active'>description</label>
           <textarea name='description' style='resize: none; height: 5em; width: 100%' onchange=${(e) => emit('settings:storage:description:update', index, e.target.value)}>${item.description}</textarea>
           <label for='active'>active</label>
-          <input type='checkbox' name='active' style='margin-left: 10px;' onchange=${(e) => emit('settings:storage:active:update', index)} ${item.active ? 'checked' : ''} value=${item.active ? true : false}>
+          <input type='checkbox' name='active' style='margin-left: 10px; margin-bottom: 10px;' onchange=${(e) => emit('settings:storage:active:update', index)} ${item.active ? 'checked' : ''} value=${item.active ? true : false}>
+          <a title='delete storage'><div style='cursor: pointer;' onclick=${() => emit('settings:storage:delete', index)}>${DeleteIcon()}</div></a>
         </div>`
       })
       return html`<div>
@@ -85,6 +85,15 @@ function StorageTab (config) {
       return { storages }
     }
   }
+}
+
+const DeleteIcon = () => {
+  return html`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20px" height="20px" viewBox="0 0 482.428 482.429">
+  <path d="M381.163,57.799h-75.094C302.323,25.316,274.686,0,241.214,0c-33.471,0-61.104,25.315-64.85,57.799h-75.098 c-30.39,0-55.111,24.728-55.111,55.117v2.828c0,23.223,14.46,43.1,34.83,51.199v260.369c0,30.39,24.724,55.117,55.112,55.117 h210.236c30.389,0,55.111-24.729,55.111-55.117V166.944c20.369-8.1,34.83-27.977,34.83-51.199v-2.828 C436.274,82.527,411.551,57.799,381.163,57.799z M241.214,26.139c19.037,0,34.927,13.645,38.443,31.66h-76.879 C206.293,39.783,222.184,26.139,241.214,26.139z M375.305,427.312c0,15.978-13,28.979-28.973,28.979H136.096 c-15.973,0-28.973-13.002-28.973-28.979V170.861h268.182V427.312z M410.135,115.744c0,15.978-13,28.979-28.973,28.979H101.266 c-15.973,0-28.973-13.001-28.973-28.979v-2.828c0-15.978,13-28.979,28.973-28.979h279.897c15.973,0,28.973,13.001,28.973,28.979 V115.744z" />
+  <path d="M171.144,422.863c7.218,0,13.069-5.853,13.069-13.068V262.641c0-7.216-5.852-13.07-13.069-13.07 c-7.217,0-13.069,5.854-13.069,13.07v147.154C158.074,417.012,163.926,422.863,171.144,422.863z" />
+  <path d="M241.214,422.863c7.218,0,13.07-5.853,13.07-13.068V262.641c0-7.216-5.854-13.07-13.07-13.07 c-7.217,0-13.069,5.854-13.069,13.07v147.154C228.145,417.012,233.996,422.863,241.214,422.863z" />
+  <path d="M311.284,422.863c7.217,0,13.068-5.853,13.068-13.068V262.641c0-7.216-5.852-13.07-13.068-13.07 c-7.219,0-13.07,5.854-13.07,13.07v147.154C298.213,417.012,304.067,422.863,311.284,422.863z"/>
+</svg>`
 }
 
 module.exports = StorageTab

--- a/components/settings/storage.js
+++ b/components/settings/storage.js
@@ -77,7 +77,7 @@ function StorageTab (config) {
       })
       return html`<div>
         ${content}
-        <div style='cursor: pointer; margin: 5px; padding: 2px; border: 1px solid #999; width: 14px; text-align: center;' onclick=${() => emit('settings:storage:add')}>+</div>
+        <a title='add storage'><div style='cursor: pointer; margin: 5px; padding: 2px; border: 1px solid #999; width: 14px; text-align: center;' onclick=${() => emit('settings:storage:add')}>+</div></a>
       </div>`
     },
     defaultData: function () {


### PR DESCRIPTION
* Caps max width of settings dialog for mobile in portrait (the width was wider than the screen)
* Add svg icon for delete storage button
* Move delete storage button from top right corner to make it less confusing (@substack hit that button to close the settings window)
* Add hide settings button at the bottom (this way we can utilize max width in portrait without sacrificing space to the left of the settings window)
* Add tooltips for delete storage, add storage and hide settings button

Before:

![Screenshot from 2022-03-19 14-56-18](https://user-images.githubusercontent.com/308049/159124066-b93ddfed-065a-4d27-857e-5f6abac97c84.png)

After:

![Screenshot from 2022-03-19 14-56-54](https://user-images.githubusercontent.com/308049/159124073-9769a7cb-4f23-4811-9cf1-7a0dfc6f814b.png)
