### PR TITLE
cache backends on urls to avoid recreating

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ var resl = require('resl')
 var regl = require('regl')
 
 var createStorage = require('./storage')
-var createStorageBackend = require('./storage/backend')
 
 var level = require('level')
 var sub = require('subleveldown')
@@ -122,19 +121,12 @@ app.use(function (state, emitter) {
   }
 
   function updateStorageBackend () {
-    var storage = state.storage
-    var currentUrl = storage.getBackend().getRootUrl()
-    var url = getStorageUrl()
-    if (url && url !== currentUrl) {
-      console.info('now using storage url', url)
-      state.storage.setBackend(createStorageBackend(state, url))
-      state.map.draw()
-    }
+    state.storage.updateBackend(state, getStorageUrl())
+    state.map.draw()
   }
 
   function onReady () {
-    var backend = createStorageBackend(state, getStorageUrl())
-    state.storage = createStorage(backend)
+    state.storage = createStorage(state, getStorageUrl())
 
     emitter.on('settings:updated', updateStorageBackend)
     emitter.on('map:zoom:set', updateStorageBackend)

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prepare:style": "georender-style2png node_modules/georender-style2png/example/style.json -o public/style.png",
     "prepare:wasm": "cp node_modules/eyros/2d.wasm public/eyros2d.wasm",
     "browserify": "browserify app.js | indexhtmlify --title 'peermaps' > public/index.html",
-    "browserify:webxdc": "browserify -p [ tinyify --ecmaVersion 10 ] -r ./storage/backend-webxdc.js:./storage/backend app.js | indexhtmlify --title 'peermaps (webxdc)' > public/index.html && rm -f peermaps.xdc && zip -j -r peermaps.xdc public/ && echo '>> public/ folder disk size' && du -sh public && echo '>> peermaps.xdc size' && wc -c peermaps.xdc",
+    "browserify:webxdc": "browserify -p [ tinyify --ecmaVersion 10 ] -r ./storage/backend-webxdc.js:./backend app.js | indexhtmlify --title 'peermaps (webxdc)' > public/index.html && rm -f peermaps.xdc && zip -j -r peermaps.xdc public/ && echo '>> public/ folder disk size' && du -sh public && echo '>> peermaps.xdc size' && wc -c peermaps.xdc",
     "web": "budo app.js -l -d public",
-    "webxdc": "concurrently \"budo app.js -l -d public -- -r ./storage/backend-webxdc.js:./storage/backend\" \"webxdc-dev run http://localhost:9966\""
+    "webxdc": "concurrently \"budo app.js -l -d public -- -r ./storage/backend-webxdc.js:./backend\" \"webxdc-dev run http://localhost:9966\""
   }
 }

--- a/storage/backend.js
+++ b/storage/backend.js
@@ -22,8 +22,6 @@ function createStorageBackend (state, url) {
       ram: createIdbStorage(url),
       debug
     })
-  } else {
-    console.warn('missing protocol handler for url', url)
   }
 }
 

--- a/storage/backend.js
+++ b/storage/backend.js
@@ -13,15 +13,14 @@ function createIdbStorage (url) {
 
 function createStorageBackend (state, url) {
   var protocol = typeof url === 'string' ? url.split('://')[0] : ''
+  var debug = state.params.debug
   if (protocol.startsWith('http')) {
-    console.info('creating http backend for url', url)
-    return createHttpBackend(url, { debug: state.params.debug })
+    return createHttpBackend(url, { debug })
   } else if (protocol === 'hyper') {
-    console.info('creating hyperdrive storage for url', url)
     return createHyperdriveBackend(url, {
       swarmOpts: config.swarmOpts,
       ram: createIdbStorage(url),
-      debug: true
+      debug
     })
   } else {
     console.warn('missing protocol handler for url', url)

--- a/storage/index.js
+++ b/storage/index.js
@@ -38,19 +38,21 @@ module.exports = function (STATE, URL) {
     }
   }
 
+  // TODO use throw below on nyi methods
+
   var storageFn = function (name) {
     return {
       write: function (offset, buf, cb) {
-        throw new Error('write not implemented')
+        cb(new Error('write not implemented'))
       },
       truncate: function (length, cb) {
-        throw new Error('truncate not implemented')
+        cb(new Error('truncate not implemented'))
       },
       del: function (cb) {
-        throw new Error('del not implemented')
+        cb(new Error('del not implemented'))
       },
       sync: function (cb) {
-        throw new Error('sync not implemented')
+        cb(new Error('sync not implemented'))
       },
       length: function (cb) {
         backend.length(name, cb)

--- a/storage/index.js
+++ b/storage/index.js
@@ -38,8 +38,6 @@ module.exports = function (STATE, URL) {
     }
   }
 
-  // TODO use throw below on nyi methods
-
   var storageFn = function (name) {
     return {
       write: function (offset, buf, cb) {

--- a/storage/index.js
+++ b/storage/index.js
@@ -38,21 +38,19 @@ module.exports = function (STATE, URL) {
     }
   }
 
-  // TODO use throw below on nyi methods
-
   var storageFn = function (name) {
     return {
       write: function (offset, buf, cb) {
-        cb(new Error('write not implemented'))
+        throw new Error('write not implemented')
       },
       truncate: function (length, cb) {
-        cb(new Error('truncate not implemented'))
+        throw new Error('truncate not implemented')
       },
       del: function (cb) {
-        cb(new Error('del not implemented'))
+        throw new Error('del not implemented')
       },
       sync: function (cb) {
-        cb(new Error('sync not implemented'))
+        throw new Error('sync not implemented')
       },
       length: function (cb) {
         backend.length(name, cb)

--- a/storage/index.js
+++ b/storage/index.js
@@ -5,7 +5,7 @@ var createStorageBackend = require('./backend')
  */
 module.exports = function (STATE, URL) {
   var backend = undefined
-  var backendCache = {}
+  var cache = {}
 
   // TODO add some clean up functionality in update for cached backends
   // that no longer should stay alive to clean up resources etc
@@ -15,7 +15,7 @@ module.exports = function (STATE, URL) {
     backend = createStorageBackend(state, url)
     if (backend) {
       if (debug) console.log('storage: created new backend for url', url)
-      backendCache[url] = backend
+      cache[url] = backend
     } else {
       console.warn('storage: missing protocol handler for url', url)
     }
@@ -24,7 +24,7 @@ module.exports = function (STATE, URL) {
   function updateBackend (state, url) {
     var debug = state.params.debug
     if (backend) {
-      var cached = backendCache[url]
+      var cached = cache[url]
       if (cached && cached === backend) {
         if (debug) console.log('storage: not updating backend')
       } else if (cached) {


### PR DESCRIPTION
Improves how we handle storages

* cached backends
* move details to `./storage/index.js` from `app.js`
* check `debug` for more verbose logging