### PR TITLE
read font from p2p archive

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -3,6 +3,20 @@
   "style": {
     "url": "style.png"
   },
+  "fonts": {
+    "endpoints": [
+      {
+        "url": "https://ipfs.io/ipfs/QmNQCPGV3XZrtNdQyMbZhSJcGisg4xCFyxeHs1tacrdETm/DejaVuSans.qbzf",
+        "description": "DejaVuSans on ipfs",
+        "active": true
+      },
+      {
+        "url": "hyper://126065f6b93924f976034b84ce74d9d570a44903ce9d110069a7aa65ddccd507/DejaVuSans.qbzf",
+        "description": "DejaVuSans on hyperdrive",
+        "active": false
+      }
+    ]
+  },
   "swarmOpts": {
     "bootstrap": [
       "wss://hyperswarm.linkping.org",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "hyperswarm-web": "^2.2.0",
     "level": "^7.0.1",
     "mixmap": "^1.5.2",
-    "mixmap-peermaps": "^1.2.0",
+    "mixmap-peermaps": "^1.4.1",
     "pump": "^3.0.0",
     "random-access-idb": "^1.2.2",
     "random-access-memory": "^4.1.0",

--- a/store/mixmap.js
+++ b/store/mixmap.js
@@ -64,6 +64,7 @@ module.exports = function (state, emitter) {
         eyros,
         storage: state.storage,
         wasmSource: fetch('eyros2d.wasm'),
+        font: maybeFetchFont(),
         style
       })
     }
@@ -81,6 +82,12 @@ module.exports = function (state, emitter) {
   function updateStorageBackend () {
     state.storage.updateBackend(state, getStorageUrl())
     state.map.draw()
+  }
+
+  function maybeFetchFont() {
+    var font = state.settings.getFont()
+    if (!font) return undefined
+    return fetch(font)
   }
 
   if (state.params.data) {

--- a/store/params.js
+++ b/store/params.js
@@ -4,6 +4,7 @@ module.exports = function (state, emitter) {
   state.params = {
     data: '',
     bbox: config.bbox,
+    font: config.font,
     style: config.style,
     debug: false
   }
@@ -22,6 +23,9 @@ module.exports = function (state, emitter) {
     if (state.params.debug === '') state.params.debug = true
     if (state.params.debug === 'false') state.params.debug = false
     if (state.params.debug === '0') state.params.debug = false
+  }
+  if (qparams.has('font')) {
+    state.params.font = { endpoints: qparams.getAll('font').map(fixURL) }
   }
 }
 

--- a/store/params.js
+++ b/store/params.js
@@ -4,7 +4,7 @@ module.exports = function (state, emitter) {
   state.params = {
     data: '',
     bbox: config.bbox,
-    font: config.font,
+    fonts: config.fonts,
     style: config.style,
     debug: false
   }
@@ -25,7 +25,7 @@ module.exports = function (state, emitter) {
     if (state.params.debug === '0') state.params.debug = false
   }
   if (qparams.has('font')) {
-    state.params.font = { endpoints: qparams.getAll('font').map(fixURL) }
+    state.params.fonts = { endpoints: qparams.getAll('font').map(fixURL) }
   }
 }
 

--- a/store/settings.js
+++ b/store/settings.js
@@ -198,7 +198,7 @@ Settings.prototype.getSearchEndpoint = function () {
 }
 
 Settings.prototype.getFont = function () {
-  var endpoints = (this.params.font || {}).endpoints || []
+  var endpoints = (this.params.fonts || {}).endpoints || []
   var fallback
   for (var i = 0; i < endpoints.length; ++i) {
     var endpoint = endpoints[i]

--- a/store/settings.js
+++ b/store/settings.js
@@ -17,6 +17,7 @@ function Settings (state, emitter) {
   self.dirty = false
   self.canReload = false
   self.width = 550
+  self.params = state.params
 
   self.tabs = [
     {
@@ -193,6 +194,22 @@ Settings.prototype.getSearchEndpoint = function () {
     return fallback.url
   } else {
     console.warn('no matching search endpoint')
+  }
+}
+
+Settings.prototype.getFont = function () {
+  var endpoints = (this.params.font || {}).endpoints || []
+  var fallback
+  for (var i = 0; i < endpoints.length; ++i) {
+    var endpoint = endpoints[i]
+    if (typeof endpoint.url === 'string' && endpoint.active) {
+      if (!fallback) fallback = endpoint
+    }
+  }
+  if (fallback) {
+    return fallback.url
+  } else {
+    console.warn('no matching font endpoint')
   }
 }
 


### PR DESCRIPTION
This patch tracks some upstream work in mixmap-georender and mixmap-peermaps to add font rendering with qbzf instead of the jank and slow canvas text rendering we had before. There is a p2p archive for qbzf font data in the data repo and this adds a default for DejaVuSans which is tested and works the best right now. This is going to get more complicated later with arrays of fonts and glyph manifests to determine which fonts to asynchronously load depending on encountered characters but this is a start.