### PR TITLE
Fix button hover on mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,9 +94,7 @@ app.route('*', function (state, emit) {
         top: 7em;
         left: 4em;
       }
-      .buttons button:hover {
-        opacity: 100%;
-      }
+      ${state.window.hasTouch ? '' : '.buttons button:hover { opacity: 100%; }'}
       .hide {
         display: none;
       }

--- a/app.js
+++ b/app.js
@@ -164,15 +164,15 @@ app.route('*', function (state, emit) {
     </style>
     <div class="ui-overlay">
       <div class="buttons left-top-buttons">
-        <button title=${l('pan_north')} class="arrow north" onclick=${panNorth}></button>
-        <button title=${l('pan_west')} class="arrow west" onclick=${panWest}></button>
-        <button title=${l('pan_east')} class="arrow east" onclick=${panEast}></button>
-        <button title=${l('pan_south')} class="arrow south" onclick=${panSouth}></button>
-        <button style="top: 4.5em; left: 6em;" onclick=${zoomIn}><div title=${l('zoom_in')} class="emoji-icon-large">🔎</div></button>
-        <button style="top: 4.5em; left: 3em;" onclick=${zoomOut}><div title=${l('zoom_out')} class="emoji-icon-small">🔎</div></button>
+        <button title=${l('pan_north')} class="opacity arrow north" onclick=${panNorth}></button>
+        <button title=${l('pan_west')} class="opacity arrow west" onclick=${panWest}></button>
+        <button title=${l('pan_east')} class="opacity arrow east" onclick=${panEast}></button>
+        <button title=${l('pan_south')} class="opacity arrow south" onclick=${panSouth}></button>
+        <button style="top: 4.5em; left: 6em;" class="opacity" onclick=${zoomIn}><div title=${l('zoom_in')} class="emoji-icon-large">🔎</div></button>
+        <button style="top: 4.5em; left: 3em;" class="opacity" onclick=${zoomOut}><div title=${l('zoom_out')} class="emoji-icon-small">🔎</div></button>
       </div>
       <div class="buttons right-top-buttons">
-        <button class="toggle-settings" onclick=${toggleSettings}><div title="${settings.show ? l('close_settings') : l('open_settings')}" class="emoji-icon-large">⚙</div></button>
+        <button class="toggle-settings" class="opacity" onclick=${toggleSettings}><div title="${settings.show ? l('close_settings') : l('open_settings')}" class="emoji-icon-large">⚙</div></button>
       </div>
       ${view.settings(state, emit)}
     </div>

--- a/app.js
+++ b/app.js
@@ -29,9 +29,6 @@ app.route('*', function (state, emit) {
       svg {
         fill: grey;
       }
-      svg:hover {
-        fill: white;
-      }
       .ui-overlay {
         z-index: 2000;
       }

--- a/app.js
+++ b/app.js
@@ -182,7 +182,7 @@ app.route('*', function (state, emit) {
       ${view.settings(state, emit)}
     </div>
     ${state.mix.render()}
-    ${state.map.render({ width: state.width, height: state.height })}
+    ${state.map.render({ width: state.window.width, height: state.window.height })}
   </body>`
 
 

--- a/store/window.js
+++ b/store/window.js
@@ -1,5 +1,7 @@
 module.exports = function (state, emitter) {
-  state.window = {}
+  state.window = {
+    hasTouch: 'ontouchstart' in document.documentElement
+  }
 
   window.addEventListener('keydown', function (ev) {
     if (ev.code === 'Digit0') {

--- a/store/window.js
+++ b/store/window.js
@@ -20,4 +20,27 @@ module.exports = function (state, emitter) {
     state.window.height = window.innerHeight
     emitter.emit('render')
   })
+
+  if (state.window.hasTouch) {
+    window.addEventListener('mousedown', function (ev) {
+      var button = getOpacityButtonElement(ev.target)
+      if (button) {
+        button.style.opacity = '100%'
+        setTimeout(function () { button.style.opacity = '30%' }, 200)
+      }
+    })
+  }
+}
+
+/**
+ * Check if a target or its parent is an opacity button in the ui overlay
+ */
+function getOpacityButtonElement (target) {
+  var button
+  if (target.nodeName === 'BUTTON') {
+    button = target
+  } else if (target.parentElement.nodeName === 'BUTTON') {
+    button = target.parentElement
+  }
+  return button && button.classList.contains('opacity') && button
 }

--- a/store/window.js
+++ b/store/window.js
@@ -1,4 +1,6 @@
 module.exports = function (state, emitter) {
+  state.window = {}
+
   window.addEventListener('keydown', function (ev) {
     if (ev.code === 'Digit0') {
       emitter.emit('map:zoom:set', 6)
@@ -8,11 +10,12 @@ module.exports = function (state, emitter) {
       emitter.emit('map:zoom:add', +1)
     }
   })
-  state.width = window.innerWidth
-  state.height = window.innerHeight
+
+  state.window.width = window.innerWidth
+  state.window.height = window.innerHeight
   window.addEventListener('resize', function (ev) {
-    state.width = window.innerWidth
-    state.height = window.innerHeight
+    state.window.width = window.innerWidth
+    state.window.height = window.innerHeight
     emitter.emit('render')
   })
 }


### PR DESCRIPTION
* disables hover if we're running on mobile (support for touch)
* if on mobile: sets opacity on buttons to 100% when clicking it and flips back to 30%

This fixes problems on mobile where you click on e.g. a pan or zoom button and the button stays in the hovered state and you need to click outside the button in order for the opacity to toggle back. So in the browser it works like before, but on mobile we toggle the opacity when clicking the button rather than with hover.